### PR TITLE
custom fields not displaying 

### DIFF
--- a/core/controllers/field_group.php
+++ b/core/controllers/field_group.php
@@ -120,7 +120,7 @@ class acf_field_group
 
 		
 		// get field from postmeta
-		$rows = $wpdb->get_results( $wpdb->prepare("SELECT meta_key FROM $wpdb->postmeta WHERE post_id = %d AND meta_key LIKE %s", $post_id, 'field\_%'), ARRAY_A);
+		$rows = $wpdb->get_results( $wpdb->prepare("SELECT meta_key FROM $wpdb->postmeta WHERE post_id = %d AND meta_key LIKE 'field\_%%'", $post_id, false), ARRAY_A);
 		
 		
 		if( $rows )


### PR DESCRIPTION
I use to Wordpress with postgresql and When create a custom post, this not displayed in ACF Settings, I followed the next discussion http://wordpress.org/support/topic/new-custom-fields-not-displaying?replies=31
