### PR TITLE
Updated export regex to not break on single quote. Fixes #191

### DIFF
--- a/core/controllers/export.php
+++ b/core/controllers/export.php
@@ -384,7 +384,7 @@ if(function_exists("register_field_group"))
 				$html = str_replace("\n", "\n\t", $html);
 				
 				// add the WP __() function to specific strings for translation in theme
-				$html = preg_replace("/'label'(.*?)('.*?')/", "'label'$1__($2)", $html);
+				$html = preg_replace("/'label'(.*?)('[^'\\\\]*(?:\\\\.[^'\\\\]*)*')/", "'label'$1__($2)", $html);
 				$html = preg_replace("/'instructions'(.*?)('.*?')/", "'instructions'$1__($2)", $html);
 				
 								


### PR DESCRIPTION
My original fix for this was to just remove the question mark:
`$html = preg_replace("/'label'(.*?)('.*')/", "'label'$1__($2)", $html);`

But after Googling the problem I found this answer:
http://stackoverflow.com/questions/5695240/php-regex-to-ignore-escaped-quotes-within-quotes

This implementation seems more robust.