### PR TITLE
WYSIWYG Field - resize tool in the incorrect position for wordpress 3.8

### DIFF
--- a/css/input.css
+++ b/css/input.css
@@ -212,10 +212,6 @@
 	min-height: 250px;
 }
 
-#post-body .acf_wysiwyg .wp_themeSkin .mceStatusbar a.mceResize {
-	top: -2px !important;
-}
-
 .acf_wysiwyg .wp-editor-container {
 	background: #fff;
 	border-color: #CCCCCC #CCCCCC #DFDFDF;


### PR DESCRIPTION
Removed: 
# post-body .acf_wysiwyg .wp_themeSkin .mceStatusbar a.mceResize {

top: -2px !important;
}
to position the resize tool in the bottom right of the editor in wordpress 3.8
