### PR TITLE
Removed the deprecated function like_escape

### DIFF
--- a/core/fields/relationship.php
+++ b/core/fields/relationship.php
@@ -113,7 +113,8 @@ class acf_field_relationship extends acf_field
 	    
 	    if ( $title = $wp_query->get('like_title') )
 	    {
-	        $where .= " AND " . $wpdb->posts . ".post_title LIKE '%" . esc_sql( like_escape(  $title ) ) . "%'";
+	    	$title = $wpdb->esc_like( $title );
+	        $where .= " AND " . $wpdb->posts . ".post_title LIKE '%" . esc_sql( $title ) . "%'";
 	    }
 	    
 	    return $where;


### PR DESCRIPTION
Removed the deprecated function like_escape() and replaced with $wpdb->esc_like() within the acf_field_relationship::posts_where() to remove deprecated warning when searching for posts in relationship custom field. Which would result in no results being displayed via ajax request.