### PR TITLE
Better French translation for the "Other" wording.

### DIFF
--- a/lang/acf-fr_FR.po
+++ b/lang/acf-fr_FR.po
@@ -1410,7 +1410,7 @@ msgstr "Bouton radio"
 
 #: ../core/fields/radio.php:102 ../core/views/meta_box_location.php:91
 msgid "Other"
-msgstr "Sections de l'admin WordPress"
+msgstr "Autre"
 
 #: ../core/fields/radio.php:145
 msgid "Enter your choices one per line"


### PR DESCRIPTION
Hi!

There's a translation error about the "Other" string.

In French, it has been translated into “Sections de l'admin WordPress"”, which would literally translate into “Sections of the WordPress dashboard”, which doesn't make sense at all.

It should be translated to “Autre”.

To help you understand why it bothers me, here is a quick description: with ACF, when I add a custom radio button field to my posts, I want to allow a free choice that will be saved into the database. Which gives:

Choice 1
Choice 2
Choice 3
Sections de l'admin WordPress : [text input]

Nobody understands what this translation means; users just need to know they can type in another label.
