### PR TITLE
For image fields, check that attachment exists

### DIFF
--- a/core/fields/image.php
+++ b/core/fields/image.php
@@ -70,8 +70,10 @@ class acf_field_image extends acf_field
 		{
 			$url = wp_get_attachment_image_src($field['value'], $field['preview_size']);
 			
-			$o['class'] = 'active';
-			$o['url'] = $url[0];
+			if( $url !== false ) {
+				$o['class'] = 'active';
+				$o['url'] = $url[0];
+			}
 		}
 		
 		?>


### PR DESCRIPTION
...even if `$field['value']` is non-empty/numeric. Fixes this error for me in Chrome:

https://github.com/elliotcondon/acf/issues/377