### PR TITLE
Removing Wordpress constants and replacing with codex recommended functions

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -16,8 +16,8 @@ class acf
 {
 	// vars
 	var $settings;
-		
-	
+
+
 	/*
 	*  Constructor
 	*
@@ -30,14 +30,14 @@ class acf
 	*  @param	N/A
 	*  @return	N/A
 	*/
-	
+
 	function __construct()
 	{
 		// helpers
 		add_filter('acf/helpers/get_path', array($this, 'helpers_get_path'), 1, 1);
 		add_filter('acf/helpers/get_dir', array($this, 'helpers_get_dir'), 1, 1);
-		
-		
+
+
 		// vars
 		$this->settings = array(
 			'path'				=> apply_filters('acf/helpers/get_path', __FILE__),
@@ -47,12 +47,12 @@ class acf
 			'upgrade_version'	=> '3.4.1',
 			'include_3rd_party'	=> false
 		);
-		
-		
+
+
 		// set text domain
 		load_textdomain('acf', $this->settings['path'] . 'lang/acf-' . get_locale() . '.mo');
-		
-		
+
+
 		// actions
 		add_action('init', array($this, 'init'), 1);
 		add_action('acf/pre_save_post', array($this, 'save_post_lock'), 0);
@@ -61,8 +61,8 @@ class acf
 		add_action('acf/save_post', array($this, 'save_post'), 10);
 		add_action('acf/save_post', array($this, 'save_post_unlock'), 999);
 		add_action('acf/create_fields', array($this, 'create_fields'), 1, 2);
-		
-		
+
+
 		// filters
 		add_filter('acf/get_info', array($this, 'get_info'), 1, 1);
 		add_filter('acf/parse_types', array($this, 'parse_types'), 1, 1);
@@ -70,16 +70,16 @@ class acf
 		add_filter('acf/get_taxonomies_for_select', array($this, 'get_taxonomies_for_select'), 1, 2);
 		add_filter('acf/get_image_sizes', array($this, 'get_image_sizes'), 1, 1);
 		add_filter('acf/get_post_id', array($this, 'get_post_id'), 1, 1);
-		
-		
+
+
 		// includes
 		$this->include_before_theme();
 		add_action('after_setup_theme', array($this, 'include_after_theme'), 1);
 		add_action('after_setup_theme', array($this, 'include_3rd_party'), 1);
-		
+
 	}
-	
-	
+
+
 	/*
 	*  helpers_get_path
 	*
@@ -92,13 +92,13 @@ class acf
 	*  @param	$file (file) a reference to the file
 	*  @return	(string)
 	*/
-    
+
     function helpers_get_path( $file )
     {
         return trailingslashit(dirname($file));
     }
-    
-    
+
+
     /*
 	*  helpers_get_dir
 	*
@@ -111,42 +111,42 @@ class acf
 	*  @param	$file (file) a reference to the file
 	*  @return	(string)
 	*/
-    
+
     function helpers_get_dir( $file )
     {
         $dir = trailingslashit(dirname($file));
         $count = 0;
-        
-        
+
+
         // sanitize for Win32 installs
-        $dir = str_replace('\\' ,'/', $dir); 
-        
-        
+        $dir = str_replace('\\' ,'/', $dir);
+
+
         // if file is in plugins folder
-        $wp_plugin_dir = str_replace('\\' ,'/', WP_PLUGIN_DIR); 
-        $dir = str_replace($wp_plugin_dir, plugins_url(), $dir, $count);
-        
-        
+        $wp_plugin_dir = str_replace('\\' ,'/', plugin_dir_path( __FILE__ ));
+        $dir = str_replace($wp_plugin_dir, plugins_url( '/', __FILE__ ), $dir, $count);
+
+
         if( $count < 1 )
         {
 	        // if file is in wp-content folder
-	        $wp_content_dir = str_replace('\\' ,'/', WP_CONTENT_DIR); 
-	        $dir = str_replace($wp_content_dir, content_url(), $dir, $count);
+	        $wp_content_dir = str_replace('\\' ,'/', content_url());
+	        $dir = str_replace($wp_content_dir, content_url('/'), $dir, $count);
         }
-        
-        
+
+
         if( $count < 1 )
         {
 	        // if file is in ??? folder
-	        $wp_dir = str_replace('\\' ,'/', ABSPATH); 
+	        $wp_dir = str_replace('\\' ,'/', site_url());
 	        $dir = str_replace($wp_dir, site_url('/'), $dir);
         }
-        
+
 
         return $dir;
     }
-	
-	
+
+
 	/*
 	*  acf/get_post_id
 	*
@@ -158,28 +158,28 @@ class acf
 	*  @param	{mixed}	$post_id
 	*  @return	{mixed}	$post_id
 	*/
-	
+
 	function get_post_id( $post_id )
 	{
 		// set post_id to global
 		if( !$post_id )
 		{
 			global $post;
-			
+
 			if( $post )
 			{
 				$post_id = intval( $post->ID );
 			}
 		}
-		
-		
+
+
 		// allow for option == options
 		if( $post_id == "option" )
 		{
 			$post_id = "options";
 		}
-		
-		
+
+
 		// object
 		if( is_object($post_id) )
 		{
@@ -196,19 +196,19 @@ class acf
 				$post_id = $post_id->ID;
 			}
 		}
-		
-		
+
+
 		/*
 		*  Override for preview
-		*  
+		*
 		*  If the $_GET['preview_id'] is set, then the user wants to see the preview data.
 		*  There is also the case of previewing a page with post_id = 1, but using get_field
 		*  to load data from another post_id.
 		*  In this case, we need to make sure that the autosave revision is actually related
-		*  to the $post_id variable. If they match, then the autosave data will be used, otherwise, 
+		*  to the $post_id variable. If they match, then the autosave data will be used, otherwise,
 		*  the user wants to load data from a completely different post_id
 		*/
-		
+
 		if( isset($_GET['preview_id']) )
 		{
 			$autosave = wp_get_post_autosave( $_GET['preview_id'] );
@@ -217,13 +217,13 @@ class acf
 				$post_id = intval( $autosave->ID );
 			}
 		}
-		
-		
+
+
 		// return
 		return $post_id;
 	}
-	
-	
+
+
 	/*
 	*  get_info
 	*
@@ -236,32 +236,32 @@ class acf
 	*  @param	$i (string) the setting to get
 	*  @return	(mixed)
 	*/
-	
+
 	function get_info( $i )
 	{
 		// vars
 		$return = false;
-		
-		
+
+
 		// specific
 		if( isset($this->settings[ $i ]) )
 		{
 			$return = $this->settings[ $i ];
 		}
-		
-		
+
+
 		// all
 		if( $i == 'all' )
 		{
 			$return = $this->settings;
 		}
-		
-		
+
+
 		// return
 		return $return;
 	}
-	
-	
+
+
 	/*
 	*  parse_types
 	*
@@ -269,7 +269,7 @@ class acf
 	*  @since: 2.0.4
 	*  @created: 9/12/12
 	*/
-	
+
 	function parse_types( $value )
 	{
 		// vars
@@ -280,8 +280,8 @@ class acf
 			'value',
 			'instructions'
 		);
-		
-		
+
+
 		// is value another array?
 		if( is_array($value) )
 		{
@@ -292,11 +292,11 @@ class acf
 				{
 					continue;
 				}
-				
-				
+
+
 				// filter piece
 				$value[ $k ] = apply_filters( 'acf/parse_types', $v );
-			}	
+			}
 		}
 		else
 		{
@@ -305,8 +305,8 @@ class acf
 			{
 				$value = trim( $value );
 			}
-			
-			
+
+
 			// numbers
 			if( is_numeric($value) )
 			{
@@ -322,18 +322,18 @@ class acf
 				}
 			}
 		}
-		
-		
+
+
 		// return
 		return $value;
 	}
-	
-	
+
+
 	/*
 	*  include_before_theme
 	*
 	*  This function will include core files before the theme's functions.php file has been excecuted.
-	*  
+	*
 	*  @type	action (plugins_loaded)
 	*  @date	3/09/13
 	*  @since	4.3.0
@@ -341,62 +341,62 @@ class acf
 	*  @param	N/A
 	*  @return	N/A
 	*/
-	
+
 	function include_before_theme()
 	{
 		// incudes
 		include_once('core/api.php');
-		
+
 		include_once('core/controllers/input.php');
 		include_once('core/controllers/location.php');
 		include_once('core/controllers/field_group.php');
-		
-		
+
+
 		// admin only includes
 		if( is_admin() )
 		{
 			include_once('core/controllers/post.php');
 			include_once('core/controllers/revisions.php');
-			include_once('core/controllers/everything_fields.php');	
+			include_once('core/controllers/everything_fields.php');
 			include_once('core/controllers/field_groups.php');
 		}
-		
-		
+
+
 		// register fields
 		include_once('core/fields/_functions.php');
 		include_once('core/fields/_base.php');
-		
+
 		include_once('core/fields/text.php');
 		include_once('core/fields/textarea.php');
 		include_once('core/fields/number.php');
 		include_once('core/fields/email.php');
 		include_once('core/fields/password.php');
-		
+
 		include_once('core/fields/wysiwyg.php');
 		include_once('core/fields/image.php');
 		include_once('core/fields/file.php');
-		
+
 		include_once('core/fields/select.php');
 		include_once('core/fields/checkbox.php');
 		include_once('core/fields/radio.php');
 		include_once('core/fields/true_false.php');
-		
+
 		include_once('core/fields/page_link.php');
 		include_once('core/fields/post_object.php');
 		include_once('core/fields/relationship.php');
 		include_once('core/fields/taxonomy.php');
 		include_once('core/fields/user.php');
-		
+
 		include_once('core/fields/google-map.php');
 		include_once('core/fields/date_picker/date_picker.php');
 		include_once('core/fields/color_picker.php');
-		
+
 		include_once('core/fields/message.php');
 		include_once('core/fields/tab.php');
 
 	}
-	
-	
+
+
 	/*
 	*  include_3rd_party
 	*
@@ -409,31 +409,31 @@ class acf
 	*  @param	N/A
 	*  @return	N/A
 	*/
-	
+
 	function include_3rd_party() {
-		
+
 		// run only once
 		if( $this->settings['include_3rd_party'] )
 		{
 			return false;
 		}
-		
-		
+
+
 		// update setting
 		$this->settings['include_3rd_party'] = true;
-		
-		
+
+
 		// include 3rd party fields
 		do_action('acf/register_fields');
-		
+
 	}
-	
-	
+
+
 	/*
 	*  include_after_theme
 	*
 	*  This function will include core files after the theme's functions.php file has been excecuted.
-	*  
+	*
 	*  @type	action (after_setup_theme)
 	*  @date	3/09/13
 	*  @since	4.3.0
@@ -441,16 +441,16 @@ class acf
 	*  @param	N/A
 	*  @return	N/A
 	*/
-	
+
 	function include_after_theme() {
-		
+
 		// bail early if user has defined LITE_MODE as true
 		if( defined('ACF_LITE') && ACF_LITE )
 		{
 			return;
 		}
-		
-		
+
+
 		// admin only includes
 		if( is_admin() )
 		{
@@ -459,10 +459,10 @@ class acf
 			include_once('core/controllers/third_party.php');
 			include_once('core/controllers/upgrade.php');
 		}
-		
+
 	}
-	
-	
+
+
 	/*
 	*  init
 	*
@@ -476,10 +476,10 @@ class acf
 	*  @param	N/A
 	*  @return	N/A
 	*/
-	
+
 	function init()
 	{
-		
+
 		// Create ACF post type
 		$labels = array(
 		    'name' => __( 'Field&nbsp;Groups', 'acf' ),
@@ -491,9 +491,9 @@ class acf
 		    'view_item' => __('View Field Group', 'acf'),
 		    'search_items' => __('Search Field Groups', 'acf'),
 		    'not_found' =>  __('No Field Groups found', 'acf'),
-		    'not_found_in_trash' => __('No Field Groups found in Trash', 'acf'), 
+		    'not_found_in_trash' => __('No Field Groups found in Trash', 'acf'),
 		);
-		
+
 		register_post_type('acf', array(
 			'labels' => $labels,
 			'public' => false,
@@ -508,12 +508,12 @@ class acf
 			),
 			'show_in_menu'	=> false,
 		));
-		
-		
+
+
 		// min
 		$min = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		
-		
+
+
 		// register acf scripts
 		$scripts = array();
 		$scripts[] = array(
@@ -526,14 +526,14 @@ class acf
 			'src'		=> $this->settings['dir'] . "js/input{$min}.js",
 			'deps'		=> array('jquery', 'jquery-ui-core', 'jquery-ui-datepicker')
 		);
-		
-		
+
+
 		foreach( $scripts as $script )
 		{
 			wp_register_script( $script['handle'], $script['src'], $script['deps'], $this->settings['version'] );
 		}
-		
-		
+
+
 		// register acf styles
 		$styles = array(
 			'acf'				=> $this->settings['dir'] . 'css/acf.css',
@@ -542,20 +542,20 @@ class acf
 			'acf-input'			=> $this->settings['dir'] . 'css/input.css',
 			'acf-datepicker'	=> $this->settings['dir'] . 'core/fields/date_picker/style.date_picker.css',
 		);
-		
+
 		foreach( $styles as $k => $v )
 		{
-			wp_register_style( $k, $v, false, $this->settings['version'] ); 
+			wp_register_style( $k, $v, false, $this->settings['version'] );
 		}
-		
-		
+
+
 		// bail early if user has defined LITE_MODE as true
 		if( defined('ACF_LITE') && ACF_LITE )
 		{
 			return;
 		}
-		
-		
+
+
 		// admin only
 		if( is_admin() )
 		{
@@ -564,22 +564,22 @@ class acf
 			add_filter('post_updated_messages', array($this, 'post_updated_messages'));
 		}
 	}
-	
-	
+
+
 	/*
 	*  admin_menu
 	*
-	*  @description: 
+	*  @description:
 	*  @since 1.0.0
 	*  @created: 23/06/12
 	*/
-	
+
 	function admin_menu()
 	{
 		add_menu_page(__("Custom Fields",'acf'), __("Custom Fields",'acf'), 'manage_options', 'edit.php?post_type=acf', false, false, '80.025');
 	}
-	
-	
+
+
 	/*
 	*  post_updated_messages
 	*
@@ -591,7 +591,7 @@ class acf
 	function post_updated_messages( $messages )
 	{
 		global $post, $post_ID;
-	
+
 		$messages['acf'] = array(
 			0 => '', // Unused. Messages start at index 1.
 			1 => __('Field group updated.', 'acf'),
@@ -606,24 +606,24 @@ class acf
 			9 => __('Field group scheduled for.', 'acf'),
 			10 => __('Field group draft updated.', 'acf'),
 		);
-	
+
 		return $messages;
-	}	
-	
-	
+	}
+
+
 	/*--------------------------------------------------------------------------------------
 	*
 	*	admin_head
 	*
 	*	@author Elliot Condon
 	*	@since 1.0.0
-	* 
+	*
 	*-------------------------------------------------------------------------------------*/
-	
+
 	function admin_head()
 	{
 		?>
-<style type="text/css"> 
+<style type="text/css">
 	#adminmenu #toplevel_page_edit-post_type-acf a[href="edit.php?post_type=acf&page=acf-upgrade"]{ display: none; }
 	#adminmenu #toplevel_page_edit-post_type-acf .wp-menu-image { background-position: 1px -33px; }
 	#adminmenu #toplevel_page_edit-post_type-acf:hover .wp-menu-image,
@@ -631,22 +631,22 @@ class acf
 </style>
 		<?php
 	}
-	
-	
+
+
 	/*
 	*  get_taxonomies_for_select
 	*
-	*  @description: 
+	*  @description:
 	*  @since: 3.6
 	*  @created: 27/01/13
 	*/
-	
+
 	function get_taxonomies_for_select( $choices, $simple_value = false )
-	{	
+	{
 		// vars
 		$post_types = get_post_types();
-		
-		
+
+
 		if($post_types)
 		{
 			foreach($post_types as $post_type)
@@ -664,65 +664,65 @@ class acf
 							foreach($terms as $term)
 							{
 								$value = $taxonomy . ':' . $term->term_id;
-								
+
 								if( $simple_value )
 								{
 									$value = $term->term_id;
 								}
-								
-								$choices[$post_type_object->label . ': ' . $taxonomy][$value] = $term->name; 
+
+								$choices[$post_type_object->label . ': ' . $taxonomy][$value] = $term->name;
 							}
 						}
 					}
 				}
 			}
 		}
-		
+
 		return $choices;
 	}
-	
-	
+
+
 	/*
 	*  get_post_types
 	*
-	*  @description: 
+	*  @description:
 	*  @since: 3.5.5
 	*  @created: 16/12/12
 	*/
-	
+
 	function get_post_types( $post_types, $exclude = array(), $include = array() )
 	{
 		// get all custom post types
 		$post_types = array_merge($post_types, get_post_types());
-		
-		
+
+
 		// core include / exclude
 		$acf_includes = array_merge( array(), $include );
 		$acf_excludes = array_merge( array( 'acf', 'revision', 'nav_menu_item' ), $exclude );
-	 
-		
+
+
 		// include
 		foreach( $acf_includes as $p )
-		{					
+		{
 			if( post_type_exists($p) )
-			{							
+			{
 				$post_types[ $p ] = $p;
 			}
 		}
-		
-		
+
+
 		// exclude
 		foreach( $acf_excludes as $p )
 		{
 			unset( $post_types[ $p ] );
 		}
-		
-		
+
+
 		return $post_types;
-		
+
 	}
-	
-	
+
+
 	/*
 	*  get_image_sizes
 	*
@@ -730,13 +730,13 @@ class acf
 	*  @since 3.2.8
 	*  @created: 6/07/12
 	*/
-	
+
 	function get_image_sizes( $sizes )
 	{
 		// find all sizes
 		$all_sizes = get_intermediate_image_sizes();
-		
-		
+
+
 		// define default sizes
 		$sizes = array_merge($sizes, array(
 			'thumbnail'	=>	__("Thumbnail",'acf'),
@@ -744,8 +744,8 @@ class acf
 			'large'		=>	__("Large",'acf'),
 			'full'		=>	__("Full",'acf')
 		));
-		
-		
+
+
 		// add extra registered sizes
 		foreach( $all_sizes as $size )
 		{
@@ -754,68 +754,68 @@ class acf
 				$sizes[ $size ] = ucwords( str_replace('-', ' ', $size) );
 			}
 		}
-		
-		
+
+
 		// return array
 		return $sizes;
 	}
-	
-	
+
+
 	/*
 	*  render_fields_for_input
 	*
-	*  @description: 
+	*  @description:
 	*  @since 3.1.6
 	*  @created: 23/06/12
 	*/
-	
+
 	function create_fields( $fields, $post_id )
 	{
 		if( is_array($fields) ){ foreach( $fields as $field ){
-			
+
 			// if they didn't select a type, skip this field
 			if( !$field || !$field['type'] || $field['type'] == 'null' )
 			{
 				continue;
 			}
-			
-			
+
+
 			// set value
 			if( !isset($field['value']) )
 			{
 				$field['value'] = apply_filters('acf/load_value', false, $post_id, $field);
 				$field['value'] = apply_filters('acf/format_value', $field['value'], $post_id, $field);
 			}
-			
-			
+
+
 			// required
 			$required_class = "";
 			$required_label = "";
-			
+
 			if( $field['required'] )
 			{
 				$required_class = ' required';
 				$required_label = ' <span class="required">*</span>';
 			}
-			
-			
+
+
 			echo '<div id="acf-' . $field['name'] . '" class="field field_type-' . $field['type'] . ' field_key-' . $field['key'] . $required_class . '" data-field_name="' . $field['name'] . '" data-field_key="' . $field['key'] . '" data-field_type="' . $field['type'] . '">';
 
 				echo '<p class="label">';
 					echo '<label for="' . $field['id'] . '">' . $field['label'] . $required_label . '</label>';
 					echo $field['instructions'];
 				echo '</p>';
-				
+
 				$field['name'] = 'fields[' . $field['key'] . ']';
 				do_action('acf/create_field', $field, $post_id);
-			
+
 			echo '</div>';
-			
+
 		}}
-				
+
 	}
-	
-	
+
+
 	/*
 	*  save_post_lock
 	*
@@ -828,15 +828,15 @@ class acf
 	*  @param	{int}	$post_id
 	*  @return	{int}	$post_id
 	*/
-	
+
 	function save_post_lock( $post_id )
 	{
 		$GLOBALS['acf_save_lock'] = $post_id;
-		
+
 		return $post_id;
 	}
-	
-	
+
+
 	/*
 	*  save_post_unlock
 	*
@@ -849,32 +849,32 @@ class acf
 	*  @param	{int}	$post_id
 	*  @return	{int}	$post_id
 	*/
-	
+
 	function save_post_unlock( $post_id )
 	{
 		$GLOBALS['acf_save_lock'] = false;
-		
+
 		return $post_id;
 	}
-	
-	
+
+
 	/*
 	*  save_post
 	*
-	*  @description: 
+	*  @description:
 	*  @since: 3.6
 	*  @created: 28/01/13
 	*/
-	
+
 	function save_post( $post_id )
 	{
-		
+
 		// load from post
 		if( !isset($_POST['fields']) )
 		{
 			return $post_id;
 		}
-		
+
 
 		// loop through and save
 		if( !empty($_POST['fields']) )
@@ -884,20 +884,20 @@ class acf
 			{
 				// get field
 				$f = apply_filters('acf/load_field', false, $k );
-				
+
 				// update field
 				do_action('acf/update_value', $v, $post_id, $f );
-				
+
 			}
 			// foreach($fields as $key => $value)
 		}
 		// if($fields)
-		
-		
+
+
 		return $post_id;
 	}
 
-	
+
 }
 
 
@@ -920,12 +920,12 @@ class acf
 function acf()
 {
 	global $acf;
-	
+
 	if( !isset($acf) )
 	{
 		$acf = new acf();
 	}
-	
+
 	return $acf;
 }
 


### PR DESCRIPTION
I don't know for sure that my edits are bullet proof but they are at the very least limited. I also do not have the capabilities to fully test files being retrieved from wp-content dir or ??? dir but I applied a similar fix to the one I used in the files found in plugin dir. I can, at least, confirm that one works on my setup.

Speaking of my setup - I am using a non standard Wordpress "stack" that is commonly used among developers. This means that the plugins folder isn't always located in the default wp-content folder. Mine is in an app folder. This makes development and deployments a little more powerful.

That being said you can see that the usage of Wordpress constants poses a problem. The WP codex docs recommend plugin authors not use these constants seen [here](http://codex.wordpress.org/Determining_Plugin_and_Content_Directories). Mark Jaquith also mentions not using contstants [here](http://stackoverflow.com/a/3128891/88487).

[Here](http://support.advancedcustomfields.com/forums/topic/acf-admin-cssjs-not-loading/) is a link on the ACF support forums of someone having an issues related to this referencing of the plugin dir. If my solutions looks sound and it is implemented, I believe these types of issues will be solved.

I should say again, I haven't spent much time on this fix so I can't say that it is 100% bullet proof. I am merely presenting a request that we work together to improve the plugin by examining what can be done to address this. My fix works for now. At least for me, that is.

Thanks!

##### Removing Wordpress constants and replacing with doc recommended functions.

* Source - WordPress makes use of the following constants when determining the path to the content and plugin directories. These should not be used directly by plugins or themes, but are listed here for completeness.