### PR TITLE
Show fields on newly-added media

### DIFF
--- a/core/controllers/everything_fields.php
+++ b/core/controllers/everything_fields.php
@@ -73,7 +73,7 @@ class acf_everything_fields
 		$post_id = $post->ID;
 		
 		
-		if( !empty($screen) )
+		if( !empty($screen) && $screen->base !== 'async-upload' )
 		{
 			return $form_fields;
 		}


### PR DESCRIPTION
Steps to reproduce this bug:

Assuming there are ACF fields defined for for post_type=attachment.

1. Edit a post (i.e. /wp-admin/post.php?post=19&action=edit)
2. Press "Add Media"
3. Click the "Upload Files" tab
4. Press "Select Files"
5. Pick a file

OR

1. Visit the media library (i.e. /wp-admin/upload.php)
2. Press "Add New"
3. Press "Select Files"
4. Pick a file
5. Click the item in the media library that was just uploaded

Current incorrect behaviour: Any ACF fields defined for post_type=attachment are not shown.

After this patch is applied: The ACF fields are shown just as they are on already-uploaded media items.