### PR TITLE
Fix double click zooming in Google Map

### DIFF
--- a/js/input.js
+++ b/js/input.js
@@ -2050,20 +2050,24 @@ var acf = {
 			    
 			});
 			
+			var clickTimeout;
 			
 			google.maps.event.addListener( this.map, 'click', function( e ) {
-				
 				// reference
-			    var $el = this.$el;
-			    
+				var $el = this.$el;
 			    
 				// vars
 				var lat = e.latLng.lat(),
-					lng = e.latLng.lng();
+				    lng = e.latLng.lng();
 				
-				
-				_this.set({ $el : $el }).update( lat, lng ).sync();
+				clickTimeout = setTimeout(function(){
+					_this.set({ $el : $el }).update( lat, lng ).sync();
+				}, 300);
+			});
 			
+			// Enable double click zooming without moving the marker
+			google.maps.event.addListener( this.map, 'dblclick', function( e ) {
+				clearTimeout(clickTimeout);
 			});
 
 			


### PR DESCRIPTION
Hey @elliotcondon! Love ACF, it's saved me ridiculous amounts of time already. After some use, I've patched this into my own input.js to enable the "double click to zoom" event in Google Maps without moving the pin on the map.

The change is really basic, should be simple to implement.

Here's the description:

---

When double clicking to zoom in a Google Map, the marker gets moved beforehand (stemming from the `click` event).

This setTimeout allows for double click zooming with a delay of 300ms before triggering the marker move event. 

My own testing determined 300ms to be the best tradeoff between responsiveness and double-click speed.

Source: http://stackoverflow.com/questions/5329136/handling-click-events-in-google-maps-js-api-v3-while-ignoring-double-clicks