### PR TITLE
Fixes issue #408 - Number field validation triggers on blank min/max values.

### DIFF
--- a/core/fields/number.php
+++ b/core/fields/number.php
@@ -79,7 +79,12 @@ class acf_field_number extends acf_field
 		
 		foreach( $o as $k )
 		{
-			$e .= ' ' . $k . '="' . esc_attr( $field[ $k ] ) . '"';	
+
+			if( empty( $field[ $k ] ) && 0 !== $field[ $k ] ) {
+				continue;
+			}
+			
+			$e .= ' ' . $k . '="' . esc_attr( $field[ $k ] ) . '"';
 		}
 		
 		$e .= ' />';


### PR DESCRIPTION
Check for empty values (with an exception for zero values) fixes the validation issue from #408.