### PR TITLE
Helps solve issue with Pro registered fields...

### DIFF
--- a/core/api.php
+++ b/core/api.php
@@ -984,7 +984,7 @@ function api_acf_field_group_get_options( $options, $post_id )
 		{
 			if( $acf['id'] == $post_id )
 			{
-				$options = $acf['options'];
+				$options = (isset($acf['options'])) ? $acf['options'] : array() ;
 				break;
 			}
 		}


### PR DESCRIPTION
in wp instance while Pro is disabled and Lite is enabled. See issues:
https://github.com/inboundnow/landing-pages/issues/215#event-394447101
https://github.com/elliotcondon/acf/issues/435