### PR TITLE
Block field the_title in #441

### DIFF
--- a/core/controllers/post.php
+++ b/core/controllers/post.php
@@ -391,6 +391,10 @@ class acf_controller_post
 		{
 			$html .= '#trackbacksdiv, #screen-meta label[for=trackbacksdiv-hide] {display: none;} ';
 		}
+		if( in_array('block_title',$options['hide_on_screen']) )
+		{
+			$html .= 'label#title-prompt-text, input#title {pointer-events:none;} ';
+		}
 		
 				
 		return $html;

--- a/core/views/meta_box_options.php
+++ b/core/views/meta_box_options.php
@@ -107,6 +107,7 @@ $options = apply_filters('acf/field_group/get_options', array(), $post->ID);
 					'categories'		=>	__("Categories", 'acf'),
 					'tags'				=>	__("Tags", 'acf'),
 					'send-trackbacks'	=>	__("Send Trackbacks", 'acf'),
+					'block_title'		=>	__("Block Title", 'acf'),
 				)
 			));
 			


### PR DESCRIPTION
In some projects, we create page-slug.php and / or block the publication of the_title field posts.

Thus editing the title field is unavailable.

I decided to send this PR, because it's something I use on some clients.