### PR TITLE
Issue with multiple acf_form calls

### DIFF
--- a/core/api.php
+++ b/core/api.php
@@ -1248,8 +1248,8 @@ function acf_form( $options = array() )
 		<?php wp_editor('', 'acf_settings'); ?>
 	</div>
 	
-	<div id="poststuff">
 	<?php
+	echo '<div id="poststuff_' . $options['post_id'] . '" class="poststuff">';
 	
 	// html before fields
 	echo $options['html_before_fields'];

--- a/css/input.css
+++ b/css/input.css
@@ -13,7 +13,7 @@
 }
 
 .acf_postbox .inside,
-#poststuff .acf_postbox .inside {
+.poststuff .acf_postbox .inside {
 	margin: 0;
 	padding: 0;
 }

--- a/js/input.js
+++ b/js/input.js
@@ -909,7 +909,7 @@ var acf = {
 			
 			
 			// setup fields
-			$(document).trigger('acf/setup_fields', [ $('#poststuff') ]);
+			$(document).trigger('acf/setup_fields', [ $('.poststuff') ]);
 			
 		}, 10);
 		


### PR DESCRIPTION
Fixed an issue where having multiple acf_form's on the same HTML page would cause displaying issues because the same id (poststuff) would be used multiple times. This would result in only the first form being displayed correctly (tabs, tinyMCE). Would be nice to have this merged. Thanks for any attention :).

P.S.: The original fix was proposed by user "Marcella" here: http://support.advancedcustomfields.com/forums/topic/cant-display-on-front-end-more-than-one-field-group-with-date-picker-field/