### PR TITLE
improve text domain loading

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -49,12 +49,9 @@ class acf
 		);
 		
 		
-		// set text domain
-		load_textdomain('acf', $this->settings['path'] . 'lang/acf-' . get_locale() . '.mo');
-		
-		
 		// actions
 		add_action('init', array($this, 'init'), 1);
+		add_action('plugins_loaded', array($this,'load_plugin_textdomain'));
 		add_action('acf/pre_save_post', array($this, 'save_post_lock'), 0);
 		add_action('acf/pre_save_post', array($this, 'save_post_unlock'), 999);
 		add_action('acf/save_post', array($this, 'save_post_lock'), 0);
@@ -144,6 +141,14 @@ class acf
         
 
         return $dir;
+    }
+
+	/**
+	 * set text domain
+	 */
+    function load_plugin_textdomain()
+    {
+        load_textdomain('acf', $this->settings['path'] . 'lang/acf-' . get_locale() . '.mo');
     }
 	
 	


### PR DESCRIPTION
If #452 will not be accepted, this PR will fix the issue with broken translations of the plugin due to the too early call of the `load_textdomain()` function.