### PR TITLE
return cached result for get_field

### DIFF
--- a/core/fields/_functions.php
+++ b/core/fields/_functions.php
@@ -307,16 +307,14 @@ class acf_field_functions
 	
 	function load_field( $field, $field_key, $post_id = false )
 	{
-		// load cache
-		if( !$field )
+		$found = false;
+		$cache = wp_cache_get( 'load_field/key=' . $field_key, 'acf', false, $found);
+		
+		if ( $found ) 
 		{
-			$field = wp_cache_get( 'load_field/key=' . $field_key, 'acf' );
+			return $cache;
 		}
-		
-		
-		// load from DB
-		if( !$field )
-		{
+
 			// vars
 			global $wpdb;
 			
@@ -375,7 +373,6 @@ class acf_field_functions
 				}
 				
 			}
-		}
 		
 		
 		// apply filters


### PR DESCRIPTION
Hi Elliot,

We noticed a lot of wp_cache_set() calls made when using get_field() and tracked it down to the cache logic in load_field(). In our testing wp_cache_get() is never called, and wp_cache_set() is called for every invocation. I used the same wp_cache_get() logic from load_value() to fix it.

Also, this is beyond my familiarity of the plugin, but it also appears that the $post_id is not used for the cache key, so the same cached value is used for any post using this field. I wasn't sure if load_field() results were supposed to be unique across posts so I did not include it in this PR.