### PR TITLE
Cache optimizations: load_field

### DIFF
--- a/core/fields/_functions.php
+++ b/core/fields/_functions.php
@@ -307,10 +307,17 @@ class acf_field_functions
 	
 	function load_field( $field, $field_key, $post_id = false )
 	{
+		$provided = ! empty($field);
+
 		// load cache
 		if( !$field )
 		{
-			$field = wp_cache_get( 'load_field/key=' . $field_key, 'acf' );
+			$found = false;
+			$cached_field = wp_cache_get( 'load_field/key=' . $field_key, 'acf', false, $found );
+			if ( $found )
+			{
+				return $cached_field;
+			}
 		}
 		
 		
@@ -389,9 +396,11 @@ class acf_field_functions
 			$field = apply_filters('acf/load_field/' . $key . '=' . $field[ $key ], $field); // new filter
 		}
 		
-	
-		// set cache
-		wp_cache_set( 'load_field/key=' . $field_key, $field, 'acf' );
+		if ( ! $provided )
+		{
+			// set cache
+			wp_cache_set( 'load_field/key=' . $field_key, $field, 'acf' );
+		}
 		
 		return $field;
 	}


### PR DESCRIPTION
While debugging my memcached implementation of the cache API I came acros a lot of overhead from this specific function.

There are two different situations at hand:
1. No $field is provided and cached content is present
2. $field is provided

For the first situation the function would load the cached field, apply filters (again) and set it to cache. This would potentially re-set filters every time a field is loaded (page is requested). Also sets the field to the cache but it is already there.

The second situation is a bit more debatable, if a field is provided then the cache should not be set.
This is because it will always be pre-generated anyway, so cache is never being queried for the existence. Setting it would take up memory and data sent to the service.