### PR TITLE
This numeric format part is unnecessary. This results option name of …

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -311,21 +311,6 @@ class acf
 				$value = trim( $value );
 			}
 			
-			
-			// numbers
-			if( is_numeric($value) )
-			{
-				// check for non numeric characters
-				if( preg_match('/[^0-9]/', $value) )
-				{
-					// leave value if it contains such characters: . + - e
-					//$value = floatval( $value );
-				}
-				else
-				{
-					$value = intval( $value );
-				}
-			}
 		}
 		
 		


### PR DESCRIPTION
This code part is causing some bug in Select field with long numbers like phone numbers.
All option name is displayed as 2147483647.
![screen shot 2016-04-04 at 12 21 43 pm](https://cloud.githubusercontent.com/assets/7704768/14243705/b68861e6-fa5f-11e5-86da-e3fd7a4d81ef.png)

Original field data is as follows.
Array ( [key] => field_5627e4b9b6fae [label] => Text Message Purchased Number [name] => text_message_purchased_number [_name] => text_message_purchased_number [type] => select [order_no] => 3 [instructions] => [required] => 0 [id] => acf-field-text_message_purchased_number [class] => select [conditional_logic] => Array ( [status] => 0 [rules] => Array ( [0] => Array ( [field] => field_55de503aed85b [operator] => == [value] => ) ) [allorany] => all ) [choices] => Array ( [] => Select Text Message Purchased Number [7142438767] => 7142438767 [9542104438] => 9542104438 [7143126945] => 7143126945 [5622701199] => 5622701199 [5622781135] => 5622781135 [3057482742] => 3057482742 [4692253189] => 4692253189 [5622473783] => 5622473783 [5622658919] => 5622658919 [5622058266] => 5622058266 [5622458776] => 5622458776 [5623830934] => 5623830934 [5623830915] => 5623830915 [5623830910] => 5623830910 [5623830898] => 5623830898 [5622475611] => 5622475611 [5622475310] => 5622475310 [5622475178] => 5622475178 [5622474630] => 5622474630 [5622475946] => 5622475946 [5622475871] => 5622475871 [5622474543] => 5622474543 [4246526234] => 4246526234 [4246526079] => 4246526079 [4246525090] => 4246525090 [5622458327] => 5622458327 [5622281108] => 5622281108 [5622474918] => 5622474918 [5622829270] => 5622829270 [5622760849] => 5622760849 [7579415626] => 7579415626 [4025759200] => 4025759200 [3177599471] => 3177599471 [3853471908] => 3853471908 [9549062141] => 9549062141 [5624516356] => 5624516356 [5624516369] => 5624516369 [6262577115] => 6262577115 [2084172903] => 2084172903 [4054451197] => 4054451197 [5614690419] => 5614690419 ) [default_value] => [allow_null] => 0 [multiple] => 0 [field_group] => 33366 )

But after filtering parse_type, it is changed as follows.
Array ( [key] => field_5627e4b9b6fae [label] => Text Message Purchased Number [name] => fields[field_5627e4b9b6fae] [_name] => text_message_purchased_number [type] => select [order_no] => 3 [instructions] => [required] => 0 [id] => acf-field-text_message_purchased_number [class] => select [conditional_logic] => Array ( [status] => 0 [rules] => Array ( [0] => Array ( [field] => field_55de503aed85b [operator] => == [value] => ) ) [allorany] => all ) [choices] => Array ( [] => Select Text Message Purchased Number [7142438767] => 2147483647 [9542104438] => 2147483647 [7143126945] => 2147483647 [5622701199] => 2147483647 [5622781135] => 2147483647 [3057482742] => 2147483647 [4692253189] => 2147483647 [5622473783] => 2147483647 [5622658919] => 2147483647 [5622058266] => 2147483647 [5622458776] => 2147483647 [5623830934] => 2147483647 [5623830915] => 2147483647 [5623830910] => 2147483647 [5623830898] => 2147483647 [5622475611] => 2147483647 [5622475310] => 2147483647 [5622475178] => 2147483647 [5622474630] => 2147483647 [5622475946] => 2147483647 [5622475871] => 2147483647 [5622474543] => 2147483647 [4246526234] => 2147483647 [4246526079] => 2147483647 [4246525090] => 2147483647 [5622458327] => 2147483647 [5622281108] => 2147483647 [5622474918] => 2147483647 [5622829270] => 2147483647 [5622760849] => 2147483647 [7579415626] => 2147483647 [4025759200] => 2147483647 [3177599471] => 2147483647 [3853471908] => 2147483647 [9549062141] => 2147483647 [5624516356] => 2147483647 [5624516369] => 2147483647 [6262577115] => 2147483647 [2084172903] => 2084172903 [4054451197] => 2147483647 [5614690419] => 2147483647 ) [default_value] => [allow_null] => 0 [multiple] => 0 [field_group] => 33366 [value] => ) 