### PR TITLE
get correct language of relationship using wpml

### DIFF
--- a/core/fields/relationship.php
+++ b/core/fields/relationship.php
@@ -10,7 +10,7 @@ class acf_field_relationship extends acf_field
 	*  @since	3.6
 	*  @date	23/01/13
 	*/
-	
+
 	function __construct()
 	{
 		// vars
@@ -34,32 +34,32 @@ class acf_field_relationship extends acf_field
 							</li>
 							'
 		);
-		
-		
+
+
 		// do not delete!
     	parent::__construct();
-    	
-    	
+
+
     	// extra
 		add_action('wp_ajax_acf/fields/relationship/query_posts', array($this, 'query_posts'));
 		add_action('wp_ajax_nopriv_acf/fields/relationship/query_posts', array($this, 'query_posts'));
 	}
-	
-	
+
+
 	/*
 	*  load_field()
-	*  
+	*
 	*  This filter is appied to the $field after it is loaded from the database
-	*  
+	*
 	*  @type filter
 	*  @since 3.6
 	*  @date 23/01/13
-	*  
+	*
 	*  @param $field - the field array holding all the field options
-	*  
+	*
 	*  @return $field - the field array holding all the field options
 	*/
-	
+
 	function load_field( $field )
 	{
 		// validate post_type
@@ -68,38 +68,38 @@ class acf_field_relationship extends acf_field
 			$field['post_type'] = array( 'all' );
 		}
 
-		
+
 		// validate taxonomy
 		if( !$field['taxonomy'] || !is_array($field['taxonomy']) || in_array('', $field['taxonomy']) )
 		{
 			$field['taxonomy'] = array( 'all' );
 		}
-		
-		
+
+
 		// validate result_elements
 		if( !is_array( $field['result_elements'] ) )
 		{
 			$field['result_elements'] = array();
 		}
-		
+
 		if( !in_array('post_title', $field['result_elements']) )
 		{
 			$field['result_elements'][] = 'post_title';
 		}
-		
-		
+
+
 		// filters
 		if( !is_array( $field['filters'] ) )
 		{
 			$field['filters'] = array();
 		}
-		
-		
+
+
 		// return
 		return $field;
 	}
-	
-	
+
+
 	/*
 	*  get_result
 	*
@@ -112,97 +112,98 @@ class acf_field_relationship extends acf_field
 	*  @param	$post_id (int)
 	*  @return	$post_id (int)
 	*/
-	
+
 	function get_result( $post, $field, $the_post, $options = array() ) {
-		
+
 		// right aligned info
 		$title = '<span class="relationship-item-info">';
-			
+
 			if( in_array('post_type', $field['result_elements']) ) {
-				
+
 				$post_type_object = get_post_type_object( $post->post_type );
 				$title .= $post_type_object->labels->singular_name;
-				
+
 			}
-			
-			
+
+
 			// WPML
-			if( !empty($options['lang']) ) {
-				
-				$title .= ' (' . $options['lang'] . ')';
-				
-			} elseif( defined('ICL_LANGUAGE_CODE') ) {
-				
+			if(function_exists('wpml_get_language_information')){
+
+				$lang = wpml_get_language_information($post->ID);
+				$title .= ' (' . $lang['display_name'] . ')';
+
+			}elseif( defined('ICL_LANGUAGE_CODE') ) {
+
 				$title .= ' (' . ICL_LANGUAGE_CODE . ')';
-				
+
 			}
-			
+
 		$title .= '</span>';
-		
-		
+
+
 		// featured_image
 		if( in_array('featured_image', $field['result_elements']) ) {
-			
+
 			$image = '';
-			
+
 			if( $post->post_type == 'attachment' ) {
-				
+
 				$image = wp_get_attachment_image( $post->ID, array(21, 21) );
-				
+
 			} else {
-				
+
 				$image = get_the_post_thumbnail( $post->ID, array(21, 21) );
-				
+
 			}
-			
+
 			$title .= '<div class="result-thumbnail">' . $image . '</div>';
-			
+
 		}
-		
-		
+
+
 		// title
 		$post_title = get_the_title( $post->ID );
-		
-		
+
+
 		// empty
 		if( $post_title === '' ) {
-			
+
 			$post_title = __('(no title)', 'acf');
-			
+
 		}
-		
-		
+
+
 		$title .= $post_title;
-		
-		
+
+
 		// status
 		if( get_post_status( $post->ID ) != "publish" ) {
-			
+
 			$title .= ' (' . get_post_status( $post->ID ) . ')';
-			
+
 		}
-			
-		
+
+
 		// filters
 		$title = apply_filters('acf/fields/relationship/result', $title, $post, $field, $the_post);
 		$title = apply_filters('acf/fields/relationship/result/name=' . $field['_name'] , $title, $post, $field, $the_post);
 		$title = apply_filters('acf/fields/relationship/result/key=' . $field['key'], $title, $post, $field, $the_post);
-		
-		
+
+
 		// return
 		return $title;
-		
+
 	}
-	
-	
+
+
 	/*
 	*  query_posts
 	*
-	*  @description: 
+	*  @description:
 	*  @since: 3.6
 	*  @created: 27/01/13
 	*/
-	
+
 	function query_posts()
    	{
    		// vars
@@ -210,8 +211,8 @@ class acf_field_relationship extends acf_field
    			'next_page_exists' => 1,
    			'html' => ''
    		);
-   		
-   		
+
+
    		// options
 		$options = array(
 			'post_type'					=>	'all',
@@ -229,76 +230,76 @@ class acf_field_relationship extends acf_field
 			'nonce'						=>	'',
 			'ancestor'					=>	false,
 		);
-		
+
 		$options = array_merge( $options, $_POST );
-		
-		
+
+
 		// validate
 		if( ! wp_verify_nonce($options['nonce'], 'acf_nonce') )
 		{
 			die();
 		}
-		
-		
+
+
 		// WPML
 		if( $options['lang'] )
 		{
 			global $sitepress;
-			
+
 			if( !empty($sitepress) )
 			{
 				$sitepress->switch_lang( $options['lang'] );
 			}
 		}
-		
-		
+
+
 		// convert types
 		$options['post_type'] = explode(',', $options['post_type']);
 		$options['taxonomy'] = explode(',', $options['taxonomy']);
-		
-		
+
+
 		// load all post types by default
 		if( in_array('all', $options['post_type']) )
 		{
 			$options['post_type'] = apply_filters('acf/get_post_types', array());
 		}
-		
-		
+
+
 		// attachment doesn't work if it is the only item in an array???
 		if( is_array($options['post_type']) && count($options['post_type']) == 1 )
 		{
 			$options['post_type'] = $options['post_type'][0];
 		}
-		
-		
+
+
 		// create tax queries
 		if( ! in_array('all', $options['taxonomy']) )
 		{
 			// vars
 			$taxonomies = array();
 			$options['tax_query'] = array();
-			
+
 			foreach( $options['taxonomy'] as $v )
 			{
-				
+
 				// find term (find taxonomy!)
 				// $term = array( 0 => $taxonomy, 1 => $term_id )
-				$term = explode(':', $v); 
-				
-				
+				$term = explode(':', $v);
+
+
 				// validate
 				if( !is_array($term) || !isset($term[1]) )
 				{
 					continue;
 				}
-				
-				
+
+
 				// add to tax array
 				$taxonomies[ $term[0] ][] = $term[1];
-				
+
 			}
-			
-			
+
+
 			// now create the tax queries
 			foreach( $taxonomies as $k => $v )
 			{
@@ -309,10 +310,10 @@ class acf_field_relationship extends acf_field
 				);
 			}
 		}
-		
+
 		unset( $options['taxonomy'] );
-		
-		
+
+
 		// load field
 		$field = array();
 		if( $options['ancestor'] )
@@ -324,62 +325,62 @@ class acf_field_relationship extends acf_field
 		{
 			$field = apply_filters('acf/load_field', array(), $options['field_key'] );
 		}
-		
-		
+
+
 		// get the post from which this field is rendered on
 		$the_post = get_post( $options['post_id'] );
-		
-		
+
+
 		// filters
 		$options = apply_filters('acf/fields/relationship/query', $options, $field, $the_post);
 		$options = apply_filters('acf/fields/relationship/query/name=' . $field['_name'], $options, $field, $the_post );
 		$options = apply_filters('acf/fields/relationship/query/key=' . $field['key'], $options, $field, $the_post );
-		
-		
+
+
 		// query
 		$wp_query = new WP_Query( $options );
 
-		
+
 		// global
 		global $post;
-		
-		
+
+
 		// loop
 		while( $wp_query->have_posts() ) {
-			
+
 			$wp_query->the_post();
-			
-			
+
+
 			// get title
 			$title = $this->get_result($post, $field, $the_post, $options);
-			
-			
+
+
 			// update html
 			$r['html'] .= '<li><a href="' . get_permalink($post->ID) . '" data-post_id="' . $post->ID . '">' . $title .  '<span class="acf-button-add"></span></a></li>';
-				
+
 		}
-		
-		
+
+
 		// next page
 		if( (int)$options['paged'] >= $wp_query->max_num_pages ) {
-			
+
 			$r['next_page_exists'] = 0;
-			
+
 		}
-		
-		
+
+
 		// reset
 		wp_reset_postdata();
-		
-		
+
+
 		// return JSON
 		echo json_encode( $r );
-		
+
 		die();
-			
+
 	}
-	
-	
+
+
 	/*
 	*  create_field()
 	*
@@ -391,20 +392,20 @@ class acf_field_relationship extends acf_field
 	*  @since	3.6
 	*  @date	23/01/13
 	*/
-	
+
 	function create_field( $field )
 	{
 		// global
 		global $post;
 
-		
+
 		// no row limit?
 		if( !$field['max'] || $field['max'] < 1 )
 		{
 			$field['max'] = 9999;
 		}
-		
-		
+
+
 		// class
 		$class = '';
 		if( $field['filters'] )
@@ -414,7 +415,7 @@ class acf_field_relationship extends acf_field
 				$class .= ' has-' . $filter;
 			}
 		}
-		
+
 		$attributes = array(
 			'max' => $field['max'],
 			's' => '',
@@ -423,30 +424,30 @@ class acf_field_relationship extends acf_field
 			'taxonomy' => implode(',', $field['taxonomy']),
 			'field_key' => $field['key']
 		);
-		
-		
+
+
 		// Lang
 		if( defined('ICL_LANGUAGE_CODE') )
 		{
 			$attributes['lang'] = ICL_LANGUAGE_CODE;
 		}
-		
-		
+
+
 		// parent
 		preg_match('/\[(field_.*?)\]/', $field['name'], $ancestor);
 		if( isset($ancestor[1]) && $ancestor[1] != $field['key'])
 		{
 			$attributes['ancestor'] = $ancestor[1];
 		}
-				
+
 		?>
 <div class="acf_relationship<?php echo $class; ?>"<?php foreach( $attributes as $k => $v ): ?> data-<?php echo $k; ?>="<?php echo $v; ?>"<?php endforeach; ?>>
-	
-	
+
+
 	<!-- Hidden Blank default value -->
 	<input type="hidden" name="<?php echo $field['name']; ?>" value="" />
-	
-	
+
+
 	<!-- Left List -->
 	<div class="relationship_left">
 		<table class="widefat">
@@ -461,14 +462,14 @@ class acf_field_relationship extends acf_field
 				<?php if(in_array( 'post_type', $field['filters']) ): ?>
 				<tr>
 					<th>
-						<?php 
-						
+						<?php
+
 						// vars
 						$choices = array(
 							'all' => __("Filter by post type",'acf')
 						);
-						
-						
+
+
 						if( in_array('all', $field['post_type']) )
 						{
 							$post_types = apply_filters( 'acf/get_post_types', array() );
@@ -481,8 +482,8 @@ class acf_field_relationship extends acf_field
 								$choices[ $post_type ] = $post_type;
 							}
 						}
-						
-						
+
+
 						// create field
 						do_action('acf/create_field', array(
 							'type'	=>	'select',
@@ -491,7 +492,7 @@ class acf_field_relationship extends acf_field
 							'value'	=>	'',
 							'choices' => $choices,
 						));
-						
+
 						?>
 					</th>
 				</tr>
@@ -505,7 +506,7 @@ class acf_field_relationship extends acf_field
 		</ul>
 	</div>
 	<!-- /Left List -->
-	
+
 	<!-- Right List -->
 	<div class="relationship_right">
 		<ul class="bl relationship_list">
@@ -516,28 +517,28 @@ class acf_field_relationship extends acf_field
 			foreach( $field['value'] as $p )
 			{
 				$title = $this->get_result($p, $field, $post);
-				
-				
+
+
 				echo '<li>
 					<a href="' . get_permalink($p->ID) . '" class="" data-post_id="' . $p->ID . '">' . $title . '<span class="acf-button-remove"></span></a>
 					<input type="hidden" name="' . $field['name'] . '[]" value="' . $p->ID . '" />
 				</li>';
-				
-					
+
+
 			}
 		}
-			
+
 		?>
 		</ul>
 	</div>
 	<!-- / Right List -->
-	
+
 </div>
 		<?php
 	}
-	
-	
-	
+
+
+
 	/*
 	*  create_options()
 	*
@@ -550,12 +551,12 @@ class acf_field_relationship extends acf_field
 	*
 	*  @param	$field	- an array holding all the field's data
 	*/
-	
+
 	function create_options( $field )
 	{
 		// vars
 		$key = $field['name'];
-		
+
 		?>
 <tr class="field_option field_option_<?php echo $this->name; ?>">
 	<td class="label">
@@ -582,14 +583,14 @@ class acf_field_relationship extends acf_field
 		<label for=""><?php _e("Post Type",'acf'); ?></label>
 	</td>
 	<td>
-		<?php 
-		
+		<?php
+
 		$choices = array(
 			'all'	=>	__("All",'acf')
 		);
 		$choices = apply_filters('acf/get_post_types', $choices);
-		
-		
+
+
 		do_action('acf/create_field', array(
 			'type'	=>	'select',
 			'name'	=>	'fields['.$key.'][post_type]',
@@ -597,7 +598,7 @@ class acf_field_relationship extends acf_field
 			'choices'	=>	$choices,
 			'multiple'	=>	1,
 		));
-		
+
 		?>
 	</td>
 </tr>
@@ -606,7 +607,7 @@ class acf_field_relationship extends acf_field
 		<label><?php _e("Filter from Taxonomy",'acf'); ?></label>
 	</td>
 	<td>
-		<?php 
+		<?php
 		$choices = array(
 			'' => array(
 				'all' => __("All",'acf')
@@ -614,8 +615,8 @@ class acf_field_relationship extends acf_field
 		);
 		$simple_value = false;
 		$choices = apply_filters('acf/get_taxonomies_for_select', $choices, $simple_value);
-		
-		
+
+
 		do_action('acf/create_field', array(
 			'type'	=>	'select',
 			'name'	=>	'fields['.$key.'][taxonomy]',
@@ -631,7 +632,7 @@ class acf_field_relationship extends acf_field
 		<label><?php _e("Filters",'acf'); ?></label>
 	</td>
 	<td>
-		<?php 
+		<?php
 		do_action('acf/create_field', array(
 			'type'	=>	'checkbox',
 			'name'	=>	'fields['.$key.'][filters]',
@@ -650,7 +651,7 @@ class acf_field_relationship extends acf_field
 		<p><?php _e("Selected elements will be displayed in each result",'acf') ?></p>
 	</td>
 	<td>
-		<?php 
+		<?php
 		do_action('acf/create_field', array(
 			'type'	=>	'checkbox',
 			'name'	=>	'fields['.$key.'][result_elements]',
@@ -672,7 +673,7 @@ class acf_field_relationship extends acf_field
 		<label><?php _e("Maximum posts",'acf'); ?></label>
 	</td>
 	<td>
-		<?php 
+		<?php
 		do_action('acf/create_field', array(
 			'type'	=>	'number',
 			'name'	=>	'fields['.$key.'][max]',
@@ -682,10 +683,10 @@ class acf_field_relationship extends acf_field
 	</td>
 </tr>
 		<?php
-		
+
 	}
-	
-	
+
+
 	/*
 	*  format_value()
 	*
@@ -701,7 +702,7 @@ class acf_field_relationship extends acf_field
 	*
 	*  @return	$value	- the modified value
 	*/
-	
+
 	function format_value( $value, $post_id, $field )
 	{
 		// empty?
@@ -712,25 +713,25 @@ class acf_field_relationship extends acf_field
 			{
 				$value = explode(',', $value);
 			}
-			
-			
+
+
 			// convert to integers
 			if( is_array($value) )
 			{
 				$value = array_map('intval', $value);
-				
+
 				// convert into post objects
 				$value = $this->get_posts( $value );
 			}
-			
+
 		}
-		
-		
+
+
 		// return value
-		return $value;	
+		return $value;
 	}
-	
-	
+
+
 	/*
 	*  format_value_for_api()
 	*
@@ -746,7 +747,7 @@ class acf_field_relationship extends acf_field
 	*
 	*  @return	$value	- the modified value
 	*/
-	
+
 	function format_value_for_api( $value, $post_id, $field )
 	{
 		// empty?
@@ -754,39 +755,39 @@ class acf_field_relationship extends acf_field
 		{
 			return $value;
 		}
-		
-		
+
+
 		// Pre 3.3.3, the value is a string coma seperated
 		if( is_string($value) )
 		{
 			$value = explode(',', $value);
 		}
-		
-		
+
+
 		// empty?
 		if( !is_array($value) || empty($value) )
 		{
 			return $value;
 		}
-		
-		
+
+
 		// convert to integers
 		$value = array_map('intval', $value);
-		
-		
+
+
 		// return format
 		if( $field['return_format'] == 'object' )
 		{
-			$value = $this->get_posts( $value );	
+			$value = $this->get_posts( $value );
 		}
-		
-		
+
+
 		// return
 		return $value;
-		
+
 	}
-	
-	
+
+
 	/*
 	*  get_posts
 	*
@@ -798,7 +799,7 @@ class acf_field_relationship extends acf_field
 	*  @param	$post_ids (array) the array of post ID's
 	*  @return	(array) an array of post objects
 	*/
-	
+
 	function get_posts( $post_ids )
 	{
 		// validate
@@ -806,12 +807,12 @@ class acf_field_relationship extends acf_field
 		{
 			return $post_ids;
 		}
-		
-		
+
+
 		// vars
 		$r = array();
-		
-		
+
+
 		// find posts (DISTINCT POSTS)
 		$posts = get_posts(array(
 			'numberposts'	=>	-1,
@@ -820,15 +821,15 @@ class acf_field_relationship extends acf_field
 			'post_status'	=>	'any',
 		));
 
-		
+
 		$ordered_posts = array();
 		foreach( $posts as $p )
 		{
 			// create array to hold value data
 			$ordered_posts[ $p->ID ] = $p;
 		}
-		
-		
+
+
 		// override value array with attachments
 		foreach( $post_ids as $k => $v)
 		{
@@ -838,13 +839,13 @@ class acf_field_relationship extends acf_field
 				$r[] = $ordered_posts[ $v ];
 			}
 		}
-		
-		
+
+
 		// return
 		return $r;
 	}
-	
-	
+
+
 	/*
 	*  update_value()
 	*
@@ -860,7 +861,7 @@ class acf_field_relationship extends acf_field
 	*
 	*  @return	$value - the modified value
 	*/
-	
+
 	function update_value( $value, $post_id, $field )
 	{
 		// validate
@@ -868,42 +869,42 @@ class acf_field_relationship extends acf_field
 		{
 			return $value;
 		}
-		
-		
+
+
 		if( is_string($value) )
 		{
 			// string
 			$value = explode(',', $value);
-			
+
 		}
 		elseif( is_object($value) && isset($value->ID) )
 		{
 			// object
 			$value = array( $value->ID );
-			
+
 		}
 		elseif( is_array($value) )
 		{
 			// array
 			foreach( $value as $k => $v ){
-			
+
 				// object?
 				if( is_object($v) && isset($v->ID) )
 				{
 					$value[ $k ] = $v->ID;
 				}
 			}
-			
+
 		}
-		
-		
+
+
 		// save value as strings, so we can clearly search for them in SQL LIKE statements
 		$value = array_map('strval', $value);
-						
-		
+
+
 		return $value;
 	}
-	
+
 }
 
 new acf_field_relationship();


### PR DESCRIPTION
In some cases all posts would show `ICL_LANGUAGE_CODE` instead of correct wpml language, with this fix this is solved
