### PR TITLE
Interact with the post after setting the terms.

### DIFF
--- a/core/fields/taxonomy.php
+++ b/core/fields/taxonomy.php
@@ -252,6 +252,8 @@ class acf_field_taxonomy extends acf_field
 			
 		}
 		
+		// Interact after setting terms
+		do_action('acf/set_terms', $post_id);
 		
 		// reset array ( WP saves twice )
 		$this->set_terms = array();


### PR DESCRIPTION
This do_action allows the developer to use the newly set terms that are saved for the post.