### PR TITLE
Fixed delete_term query.

### DIFF
--- a/core/controllers/everything_fields.php
+++ b/core/controllers/everything_fields.php
@@ -853,8 +853,8 @@ $(document).ready(function(){
 		global $wpdb;
 		
 		$values = $wpdb->query($wpdb->prepare(
-			"DELETE FROM $wpdb->options WHERE option_name LIKE %s",
-			'%' . $taxonomy . '_' . $term . '%'
+			"DELETE FROM $wpdb->options WHERE option_name LIKE '%%%s\\_%%'",
+			$taxonomy . '_' . $term
 		));
 	}
 	

--- a/core/controllers/everything_fields.php
+++ b/core/controllers/everything_fields.php
@@ -850,12 +850,16 @@ $(document).ready(function(){
 	
 	function delete_term( $term, $tt_id, $taxonomy, $deleted_term )
 	{
-		global $wpdb;
-		
-		$values = $wpdb->query($wpdb->prepare(
-			"DELETE FROM $wpdb->options WHERE option_name LIKE '%%%s\\_%%'",
-			$taxonomy . '_' . $term
-		));
+        global $wpdb;
+
+        $search = $taxonomy . '_' . $term . '_%';
+        $_search = '_' . $search;
+
+        $result = $wpdb->query($wpdb->prepare(
+            "DELETE FROM $wpdb->options WHERE option_name LIKE %s OR option_name LIKE %s",
+            str_replace('_', '\_', $search),
+            str_replace('_', '\_', $_search)
+        ));
 	}
 	
 			


### PR DESCRIPTION
Previous one was matching all wp_options with an option_name which contains a term ID starting with the same number.

Example: *%taxonomy_3%* matches *\_taxonomy_3_test* and *\_taxonomy_32_test*.

So I have moved both wildcards *%* and *_* to the query parameter and escaped them to work properly.