### PR TITLE
Only get image details for the size required.

### DIFF
--- a/core/fields/image.php
+++ b/core/fields/image.php
@@ -254,6 +254,9 @@ class acf_field_image extends acf_field
 			{
 				foreach( $image_sizes as $image_size )
 				{
+					if ( $image_size != $field['preview_size'] )
+						continue;
+
 					// find src
 					$src = wp_get_attachment_image_src( $attachment->ID, $image_size );
 					


### PR DESCRIPTION
Hi there...

I'm relatively new to ACF and WordPress, I apologise in advance if I'm wasting your time.

I have a site which uses a (custom-built) plugin to dynamically generate resized versions of images rather than creating them at upload time, and it adds significant overhead when using ACF with image fields. The plugin hooks image_downsize, which is called from wp_get_attachment_image_src, which is called from image.php (just after this change).

I have found that I get a significant performance boost with this change, because only the size configured for the field is processed, rather than all sizes. This might not be such an issue for the majority of users, but I also found a small performance boost (3-4% on an entire page load) with this change, even without our image resizing plugin. This of course will be proportional to the number of image sizes configured in core, and the number of image fields configured in ACF.

There may be (probably is) some good reason for processing all of the image sizes -- if there is, I'd be interested in what that reason is.

Also, I'm not at all proposing that this change be accepted as-is, there are probably lots of better ways to do it, I mostly wanted to start a discussion.

Thanks for your time!

Matt