### PR TITLE
It permits using or not get_pages

### DIFF
--- a/core/fields/post_object.php
+++ b/core/fields/post_object.php
@@ -152,26 +152,21 @@ class acf_field_post_object extends acf_field
 			// set post_type
 			$args['post_type'] = $post_type;
 			
-			
-			// set order
-			$get_pages = false;
-			if( is_post_type_hierarchical($post_type) && !isset($args['tax_query']) )
-			{
-				$args['sort_column'] = 'menu_order, post_title';
-				$args['sort_order'] = 'ASC';
-				
-				$get_pages = true;
-			}
-			
-			
 			// filters
 			$args = apply_filters('acf/fields/post_object/query', $args, $field, $post);
 			$args = apply_filters('acf/fields/post_object/query/name=' . $field['_name'], $args, $field, $post );
 			$args = apply_filters('acf/fields/post_object/query/key=' . $field['key'], $args, $field, $post );
 			
 			
-			if( $get_pages )
+			if( is_post_type_hierarchical($post_type) && !isset($args['tax_query']) )
 			{
+				// set order if not set with filters
+				if (!isset($args['sort_column'])) {
+					$args['sort_column'] = 'menu_order, post_title';
+				}
+				if (!isset($args['sort_order'])) {
+					$args['sort_order'] = 'ASC';
+				}
 				$posts = get_pages( $args );
 			}
 			else


### PR DESCRIPTION
I changed the *$get_pages* condition because we cannot interfere with it with the filter.
By adding a *tax_query* arg, we can force usage of *get_posts* which do the same thing but better than *get_pages*. 

For exemple:

```php
add_filter('acf/fields/post_object/query/key=field_5a168694aef91', 'my_relationship_query', 10, 3);
 
// This will filter the query with specific post IDs and preserve order of my IDs
function my_relationship_query($args, $field, $post) {
    $posts_ids = array(40, 80, 20, 42);
    $args['orderby'] = 'post__in';
    $args['tax_query'] = array();
    $args['post__in'] = $posts_ids;
    return $args;
}
```
This will allow to sort by the order of passed IDs, which is not respected by get_pages...