### PR TITLE
Fix bug in rendering of radio button attributes

### DIFF
--- a/core/fields/radio.php
+++ b/core/fields/radio.php
@@ -79,7 +79,7 @@ class acf_field_radio extends acf_field
 				
 				
 				// HTML
-				$e .= '<li><label><input id="' . esc_attr($field['id']) . '-' . esc_attr($key) . '" type="radio" name="' . esc_attr($field['name']) . '" value="' . esc_attr($key) . '" ' . esc_attr( $atts ) . ' />' . $value . '</label></li>';
+				$e .= '<li><label><input id="' . esc_attr($field['id']) . '-' . esc_attr($key) . '" type="radio" name="' . esc_attr($field['name']) . '" value="' . esc_attr($key) . '" ' . $atts . ' />' . $value . '</label></li>';
 			}
 		}
 		


### PR DESCRIPTION
Checked radio buttons currently render with malformed attributes:

```html
<input … checked=&quot;checked&quot; data-checked=&quot;checked&quot; />
```