### PR TITLE
Including option to return image as Base64

### DIFF
--- a/core/fields/image.php
+++ b/core/fields/image.php
@@ -135,7 +135,8 @@ class acf_field_image extends acf_field
 			'choices'	=> array(
 				'object'	=>	__("Image Object",'acf'),
 				'url'		=>	__("Image URL",'acf'),
-				'id'		=>	__("Image ID",'acf')
+				'id'		=>	__("Image ID",'acf'),
+				'base64'	=>	__("Image Base64",'acf')
 			)
 		));
 		?>
@@ -217,6 +218,10 @@ class acf_field_image extends acf_field
 		if( $field['save_format'] == 'url' )
 		{
 			$value = wp_get_attachment_url( $value );
+		}
+		elseif( $field['save_format'] == 'base64' )
+		{
+			$value = base64_encode( file_get_contents( wp_get_attachment_url( $value ) ) );
 		}
 		elseif( $field['save_format'] == 'object' )
 		{

--- a/lang/acf-pt_BR.po
+++ b/lang/acf-pt_BR.po
@@ -1541,6 +1541,11 @@ msgid "Image ID"
 msgstr "ID da Imagem"
 
 # @ acf
+#: core/fields/image.php:139
+msgid "Image Base64"
+msgstr "Base64 da Imagem"
+
+# @ acf
 #: core/fields/image.php:29
 msgid "Update Image"
 msgstr "Atualizar Imagem"


### PR DESCRIPTION
I wrote this little piece of code to return image content as Base64 instead of URL or ID.
I needed that for an API development. Thank you for this great plugin!